### PR TITLE
Handle "package://" file paths via ROS_PACKAGE_PATH environment variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ SET(PROJECT_NAME gepetto-viewer-corba)
 SET(PROJECT_DESCRIPTION "Corba server for gepetto-viewer")
 SET(PROJECT_URL "")
 
+SET(CLIENT_ONLY FALSE CACHE BOOL "Set to true to install the client only")
+
 SET(${PROJECT_NAME}_HEADERS
   include/gepetto/viewer/corba/windows-manager.hh
   include/gepetto/viewer/corba/server.hh
@@ -47,75 +49,80 @@ SETUP_PROJECT ()
 
 # Dependencies
 ADD_REQUIRED_DEPENDENCY("omniORB4 >= 4.1.4")
-ADD_REQUIRED_DEPENDENCY("openscenegraph >= 3.2")
-ADD_REQUIRED_DEPENDENCY("openscenegraph-osgQt")
-ADD_REQUIRED_DEPENDENCY("openthreads >= 2.6")
-ADD_REQUIRED_DEPENDENCY("gepetto-viewer")
-ADD_REQUIRED_DEPENDENCY("urdfdom")
+IF(NOT CLIENT_ONLY)
+  ADD_REQUIRED_DEPENDENCY("openscenegraph >= 3.2")
+  ADD_REQUIRED_DEPENDENCY("openscenegraph-osgQt")
+  ADD_REQUIRED_DEPENDENCY("openthreads >= 2.6")
+  ADD_REQUIRED_DEPENDENCY("gepetto-viewer")
+  ADD_REQUIRED_DEPENDENCY("urdfdom")
 
-SET(BOOST_COMPONENTS program_options system thread regex)
-SEARCH_FOR_BOOST ()
+  SET(BOOST_COMPONENTS program_options system thread regex)
+  SEARCH_FOR_BOOST ()
 
-FIND_PACKAGE(Qt4 REQUIRED QtCore QtGui QtOpenGl QtNetwork)
-FINDPYTHON(2.7 EXACT)
-FIND_PACKAGE(PythonQt COMPONENTS QtAll)
+  FIND_PACKAGE(Qt4 REQUIRED QtCore QtGui QtOpenGl QtNetwork)
+  FINDPYTHON(2.7 EXACT)
+  FIND_PACKAGE(PythonQt COMPONENTS QtAll)
 
-SET(GEPETTO_GUI_HAS_PYTHONQT ${PYTHONQT_FOUND} CACHE BOOL "Use PythonQt dependency")
+  SET(GEPETTO_GUI_HAS_PYTHONQT ${PYTHONQT_FOUND} CACHE BOOL "Use PythonQt dependency")
 
-PKG_CONFIG_APPEND_LIBS(${PROJECT_NAME})
+  PKG_CONFIG_APPEND_LIBS(${PROJECT_NAME})
 
-INCLUDE_DIRECTORIES(SYSTEM ${EIGEN3_INCLUDE_DIRS})
+  INCLUDE_DIRECTORIES(SYSTEM ${EIGEN3_INCLUDE_DIRS})
 
-SET (${PROJECT_NAME}_HEADERS_MOC
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/mainwindow.hh
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/safeapplication.hh
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/osgwidget.hh
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/tree-item.hh
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/bodytreewidget.hh
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/ledindicator.hh
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/plugin-interface.hh
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/omniorb/omniorbthread.hh
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/omniorb/url.hh
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/dialog/dialogloadrobot.hh
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/dialog/dialogloadenvironment.hh
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/dialog/pluginmanagerdialog.hh
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/pick-handler.hh
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/shortcut-factory.hh
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/selection-handler.hh
-  )
-SET (${PROJECT_NAME}_HEADERS_NO_MOC
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/fwd.hh
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/meta.hh
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/settings.hh
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/windows-manager.hh
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/color-map.hh
-  ${CMAKE_BINARY_DIR}/include/gepetto/gui/config-dep.hh
-  )
+  SET (${PROJECT_NAME}_HEADERS_MOC
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/mainwindow.hh
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/safeapplication.hh
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/osgwidget.hh
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/tree-item.hh
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/bodytreewidget.hh
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/ledindicator.hh
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/plugin-interface.hh
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/omniorb/omniorbthread.hh
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/omniorb/url.hh
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/dialog/dialogloadrobot.hh
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/dialog/dialogloadenvironment.hh
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/dialog/pluginmanagerdialog.hh
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/pick-handler.hh
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/shortcut-factory.hh
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/selection-handler.hh
+    )
+  SET (${PROJECT_NAME}_HEADERS_NO_MOC
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/fwd.hh
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/meta.hh
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/settings.hh
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/windows-manager.hh
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/color-map.hh
+    ${CMAKE_BINARY_DIR}/include/gepetto/gui/config-dep.hh
+    )
 
-SET(${PROJECT_NAME}_FORMS
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/ui/mainwindow.ui
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/ui/dialogloadrobot.ui
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/ui/dialogloadenvironment.ui
-  ${CMAKE_SOURCE_DIR}/include/gepetto/gui/ui/pluginmanagerdialog.ui
-  )
+  SET(${PROJECT_NAME}_FORMS
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/ui/mainwindow.ui
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/ui/dialogloadrobot.ui
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/ui/dialogloadenvironment.ui
+    ${CMAKE_SOURCE_DIR}/include/gepetto/gui/ui/pluginmanagerdialog.ui
+    )
 
-SET(${PROJECT_NAME}_RESOURCES ${CMAKE_SOURCE_DIR}/res/images.qrc)
+  SET(${PROJECT_NAME}_RESOURCES ${CMAKE_SOURCE_DIR}/res/images.qrc)
 
-SET(${PROJECT_NAME}_HEADERS
-  ${${PROJECT_NAME}_HEADERS}
-  ${${PROJECT_NAME}_HEADERS_MOC}
-  ${${PROJECT_NAME}_HEADERS_NO_MOC})
+  SET(${PROJECT_NAME}_HEADERS
+    ${${PROJECT_NAME}_HEADERS}
+    ${${PROJECT_NAME}_HEADERS_MOC}
+    ${${PROJECT_NAME}_HEADERS_NO_MOC})
 
-config_files(
-  include/gepetto/gui/config-dep.hh
-  src/gui/main.cc
-  )
+  config_files(
+    include/gepetto/gui/config-dep.hh
+    src/gui/main.cc
+    )
+ENDIF(NOT CLIENT_ONLY)
 
 ADD_SUBDIRECTORY(src)
-ADD_SUBDIRECTORY(src/gui)
-ADD_SUBDIRECTORY(pyplugins)
-ADD_SUBDIRECTORY(blender)
-ADD_SUBDIRECTORY(examples EXCLUDE_FROM_ALL)
-ADD_SUBDIRECTORY(tests)
+
+IF(NOT CLIENT_ONLY)
+  ADD_SUBDIRECTORY(src/gui)
+  ADD_SUBDIRECTORY(pyplugins)
+  ADD_SUBDIRECTORY(blender)
+  ADD_SUBDIRECTORY(examples EXCLUDE_FROM_ALL)
+  ADD_SUBDIRECTORY(tests)
+ENDIF(NOT CLIENT_ONLY)
 
 SETUP_PROJECT_FINALIZE()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,33 +45,53 @@ FOREACH(IDL ${IDL_SOURCES})
 
   INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/gepetto/viewer/corba/${IDL_UNDERSCORE}_idl.py
     DESTINATION ${PYTHON_SITELIB}/gepetto/corbaserver)
+
+  INSTALL(FILES ${CMAKE_SOURCE_DIR}/idl/gepetto/viewer/${IDL}.idl
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/idl/gepetto/corbaserver)
 ENDFOREACH()
 
-ADD_CUSTOM_TARGET(generate_idl_cpp DEPENDS ${ALL_IDL_CPP_STUBS})
-ADD_CUSTOM_TARGET(generate_idl_python DEPENDS ${ALL_IDL_PYTHON_STUBS})
+IF(NOT CLIENT_ONLY)
 
-ADD_LIBRARY(${LIBRARY_NAME}
-  SHARED
-  graphical-interface.impl.cpp
-  graphical-interface.impl.hh
-  windows-manager.cpp
-  server.cc
-  client.cc
-  server-private.cc
-  server-private.hh
-  ${CMAKE_CURRENT_BINARY_DIR}/gepetto/viewer/corba/graphical-interface.hh
-  ${CMAKE_CURRENT_BINARY_DIR}/gepetto/viewer/corba/graphical-interfaceSK.cc
-)
+  ADD_CUSTOM_TARGET(generate_idl_cpp DEPENDS ${ALL_IDL_CPP_STUBS})
+  ADD_CUSTOM_TARGET(generate_idl_python DEPENDS ${ALL_IDL_PYTHON_STUBS})
 
-ADD_DEPENDENCIES (${LIBRARY_NAME} generate_idl_cpp)
-ADD_DEPENDENCIES (${LIBRARY_NAME} generate_idl_python)
+  ADD_LIBRARY(${LIBRARY_NAME}
+    SHARED
+    graphical-interface.impl.cpp
+    graphical-interface.impl.hh
+    windows-manager.cpp
+    server.cc
+    client.cc
+    server-private.cc
+    server-private.hh
+    ${CMAKE_CURRENT_BINARY_DIR}/gepetto/viewer/corba/graphical-interface.hh
+    ${CMAKE_CURRENT_BINARY_DIR}/gepetto/viewer/corba/graphical-interfaceSK.cc
+  )
 
-PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} omniORB4)
-PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} gepetto-viewer)
-PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} urdfdom)
-TARGET_LINK_LIBRARIES(${LIBRARY_NAME} ${Boost_LIBRARIES})
+  ADD_DEPENDENCIES (${LIBRARY_NAME} generate_idl_cpp)
+  ADD_DEPENDENCIES (${LIBRARY_NAME} generate_idl_python)
 
-INSTALL(TARGETS ${LIBRARY_NAME} DESTINATION lib)
+  PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} omniORB4)
+  PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} gepetto-viewer)
+  PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} urdfdom)
+  TARGET_LINK_LIBRARIES(${LIBRARY_NAME} ${Boost_LIBRARIES})
+
+  INSTALL(TARGETS ${LIBRARY_NAME} DESTINATION lib)
+
+  # Standalone corba server
+  ADD_EXECUTABLE (gepetto-viewer-server corbaserver.cc)
+  TARGET_LINK_LIBRARIES(gepetto-viewer-server ${LIBRARY_NAME})
+  PKG_CONFIG_USE_DEPENDENCY(gepetto-viewer-server omniORB4)
+  #TARGET_LINK_LIBRARIES(gepetto-viewer-server ${Boost_LIBRARIES})
+
+  INSTALL (TARGETS gepetto-viewer-server DESTINATION bin)
+
+ELSE(NOT CLIENT_ONLY)
+
+  ADD_CUSTOM_TARGET(generate_idl_cpp ALL DEPENDS ${ALL_IDL_CPP_STUBS})
+  ADD_CUSTOM_TARGET(generate_idl_python ALL DEPENDS ${ALL_IDL_PYTHON_STUBS})
+
+ENDIF(NOT CLIENT_ONLY)
 
 MAKE_DIRECTORY(${CMAKE_CURRENT_BINARY_DIR}/gepetto/viewer/corba)
 
@@ -102,21 +122,3 @@ INSTALL(
   ${CMAKE_CURRENT_SOURCE_DIR}/../blender/gepettoimport.py
   DESTINATION ${PYTHON_SITELIB}/gepetto/blender
   )
-INSTALL(
-  FILES
-  ${CMAKE_SOURCE_DIR}/idl/gepetto/viewer/graphical-interface.idl
-  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/idl/gepetto/corbaserver
-)
-
-INSTALL (FILES
-  ${CMAKE_CURRENT_BINARY_DIR}/gepetto/viewer/corba/graphical-interface.hh
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gepetto/viewer/corba
-  )
-
-# Standalone corba server
-ADD_EXECUTABLE (gepetto-viewer-server corbaserver.cc)
-TARGET_LINK_LIBRARIES(gepetto-viewer-server ${LIBRARY_NAME})
-PKG_CONFIG_USE_DEPENDENCY(gepetto-viewer-server omniORB4)
-#TARGET_LINK_LIBRARIES(gepetto-viewer-server ${Boost_LIBRARIES})
-
-INSTALL (TARGETS gepetto-viewer-server DESTINATION bin)

--- a/src/gui/osgwidget.cc
+++ b/src/gui/osgwidget.cc
@@ -153,8 +153,8 @@ namespace gepetto {
       render_.start ();
 
       parent->bodyTree()->connect(this,
-          SIGNAL (clicked(QString,QVector3D)), SLOT (selectBodyByName(QString)));
-      parent->connect(this, SIGNAL (clicked(QString,QVector3D)),
+          SIGNAL (clicked(QString,QVector3D,QKeyEvent*)), SLOT (selectBodyByName(QString)));
+      parent->connect(this, SIGNAL (clicked(QString,QVector3D,QKeyEvent*)),
 		      SLOT (requestSelectJointFromBodyName(QString)));
     }
 

--- a/src/windows-manager.cpp
+++ b/src/windows-manager.cpp
@@ -258,7 +258,7 @@ namespace graphics {
     }
 
     UrdfFile::UrdfFile (const std::string& f)
-      : filename (f) {
+      : filename (urdfParser::getFilename(f)) {
         struct stat buffer;
         if (stat (filename.c_str(), &buffer) != 0) {
           perror (filename.c_str());

--- a/src/windows-manager.cpp
+++ b/src/windows-manager.cpp
@@ -972,14 +972,12 @@ namespace graphics {
 
     bool WindowsManager::addURDF (const char* urdfNameCorba,
             const char* urdfPathCorba,
-            const char* urdfPackagePathCorba)
+            const char* /*urdfPackagePathCorba*/)
     {
         const std::string urdfName (urdfNameCorba);
         const std::string urdfPath (urdfPathCorba);
-        const std::string urdfPackagePath (urdfPackagePathCorba);
         if (urdfNodeMustBeAdded (urdfName, urdfPath)) {
-          GroupNodePtr_t urdf = urdfParser::parse
-            (urdfName, urdfPath, urdfPackagePath);
+          GroupNodePtr_t urdf = urdfParser::parse (urdfName, urdfPath);
           NodePtr_t link;
           for (std::size_t i=0; i< urdf->getNumOfChildren (); i++) {
             link = urdf->getChild (i);
@@ -1005,14 +1003,13 @@ namespace graphics {
     }
 
     bool WindowsManager::addUrdfCollision (const char* urdfNameCorba,
-            const char* urdfPathCorba, const char* urdfPackagePathCorba)
+            const char* urdfPathCorba, const char* /*urdfPackagePathCorba*/)
     {
         const std::string urdfName (urdfNameCorba);
         const std::string urdfPath (urdfPathCorba);
-        const std::string urdfPackagePath (urdfPackagePathCorba);
         if (urdfNodeMustBeAdded (urdfName, urdfPath)) {
             GroupNodePtr_t urdf = urdfParser::parse
-                (urdfName, urdfPath, urdfPackagePath, "collision");
+                (urdfName, urdfPath, "collision");
             NodePtr_t link;
             for (std::size_t i=0; i< urdf->getNumOfChildren (); i++) {
                 link = urdf->getChild (i);
@@ -1039,20 +1036,18 @@ namespace graphics {
 
     void WindowsManager::addUrdfObjects (const char* urdfNameCorba,
             const char* urdfPathCorba,
-            const char* urdfPackagePathCorba,
+            const char* /*urdfPackagePathCorba*/,
             bool visual)
     {
         const std::string urdfName (urdfNameCorba);
         const std::string urdfPath (urdfPathCorba);
-        const std::string urdfPackagePath (urdfPackagePathCorba);
         if (urdfName == "") {
             throw gepetto::Error ("Parameter nodeName cannot be empty in "
                     "idl request addUrdfObjects.");
         }
         if (urdfNodeMustBeAdded (urdfName, urdfPath)) {
           GroupNodePtr_t urdf = urdfParser::parse
-            (urdfName, urdfPath, urdfPackagePath,
-             visual ? "visual" : "collision", "object");
+            (urdfName, urdfPath, visual ? "visual" : "collision", "object");
           NodePtr_t link;
           for (std::size_t i=0; i< urdf->getNumOfChildren (); i++) {
             link = urdf->getChild (i);


### PR DESCRIPTION
Follows https://github.com/humanoid-path-planner/gepetto-viewer/pull/37

The IDL API has not been updated yet. The argument "meshDataRootDir" is still passed but never used.