### PR TITLE
use dynamic_pointer_cast defined in gepetto-viewer's macros.h

### DIFF
--- a/src/windows-manager.cpp
+++ b/src/windows-manager.cpp
@@ -77,7 +77,7 @@
   }
 
 #define FIND_NODE_OF_TYPE_OR_THROW(NodeType, varname, nodename)                \
-  NodeType##Ptr_t varname (boost::dynamic_pointer_cast <NodeType>                \
+  NodeType##Ptr_t varname (dynamic_pointer_cast <NodeType>                     \
       (getNode(nodename, true)));                                              \
   if (!varname) {                                                              \
     std::ostringstream oss;                                                    \


### PR DESCRIPTION
This fixes compilation on fedora26 and has no effects on 14.04 & 16.04